### PR TITLE
let websocket connect to website host by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This web frontend is intended to run inferences against quantized ggml language 
 --------------|---------------------------------------------------------------
 CONFIGURATION | Specifies which configuration file from the configuration folder will be loaded (default.py if not set)
 MODELS_FOLDER | Path to your LLMs. By default it will use "models" in the root folder of the project
-WSURL         | external URL for websocket connection. Will be rendered into the HTML/Javascript. Default ws://localhost. Overwrite if running behind a reverse proxy 
+WSURL         | external URL for websocket connection. Will be rendered into the HTML/Javascript. If not set, website hostname will be used. Overwrite this if running behind a reverse proxy 
 
 # Builtin Chat Commands
 As I am to lazy to build a sophisticated UI some options can only be accessed by chat commands. Type in `!help` to get a list of available commands

--- a/app/main.py
+++ b/app/main.py
@@ -65,7 +65,7 @@ async def get(request: Request):
 async def get(request: Request):
     return templates.TemplateResponse("inference.js", {
         "request": request,
-        "wsurl": os.getenv("WSURL") if os.getenv("WSURL") != None else "ws://localhost:%s" % DEFAULT_PORT, 
+        "wsurl": os.getenv("WSURL", ""),
         "res": res,
         "conf": conf
     })

--- a/app/templates/inference.js
+++ b/app/templates/inference.js
@@ -102,7 +102,11 @@ function hideResponseTokens() {
 }
 
 function connect() {
-    ws = new WebSocket("{{ wsurl }}/inference");
+    let wsBaseUrl = "{{ wsurl }}";
+    if (wsBaseUrl === "") {
+        wsBaseUrl = "ws://" + window.location.host;
+    }
+    ws = new WebSocket(wsBaseUrl + "/inference");
     ws.onmessage = function (event) {
         var messages = document.getElementById('messages');
         var data = JSON.parse(event.data);


### PR DESCRIPTION
This makes the WSURL env var optional, which makes configuration much easier when accessing the website behind a redirected port: the JS code will automatically use the host and port under which the website was accessed in the first place, which (I guess) should be correct in most cases.